### PR TITLE
Add DeckListDiffableDataSource

### DIFF
--- a/Spreppy/Deck List/DeckListViewController.swift
+++ b/Spreppy/Deck List/DeckListViewController.swift
@@ -15,7 +15,7 @@ class DeckListViewController: UIViewController,
     private lazy var viewModel = DeckListViewModel(
         repository: DeckCoreDateRepository(persistentContainer: AppDelegate.sharedAppDelegate.persistentContainer),
         delegate: self)
-    private lazy var dataSource = makeDataSource()
+    private lazy var dataSource = DeckListDiffableDataSource(viewModel: viewModel, tableView: tableView)
     private var state = DeckListState()
 
     private lazy var tableView = makeTableView()
@@ -106,12 +106,21 @@ class DeckListViewController: UIViewController,
         tableView.delegate = self
         return tableView
     }
+}
 
-    private func makeDataSource() -> UITableViewDiffableDataSource<Int, DeckModel> {
-        UITableViewDiffableDataSource<Int, DeckModel>(tableView: tableView) { _, _, deckModel in
+private class DeckListDiffableDataSource: UITableViewDiffableDataSource<Int, DeckModel> {
+    private let viewModel: DeckListViewModel
+    
+    init(viewModel: DeckListViewModel, tableView: UITableView) {
+        self.viewModel = viewModel
+        super.init(tableView: tableView) { _, _, deckModel in
             let cell = DeckCell()
             cell.configure(with: deckModel)
             return cell
         }
+    }
+    
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        // TODO
     }
 }

--- a/Spreppy/Deck List/DeckListViewController.swift
+++ b/Spreppy/Deck List/DeckListViewController.swift
@@ -69,7 +69,7 @@ class DeckListViewController: UIViewController,
     func update(state: DeckListState) {
         let oldState = self.state
         self.state = state
-        
+
         if oldState.decks != state.decks {
             var snapshot = NSDiffableDataSourceSnapshot<Int, DeckModel>()
             snapshot.appendSections([0])
@@ -110,7 +110,7 @@ class DeckListViewController: UIViewController,
 
 private class DeckListDiffableDataSource: UITableViewDiffableDataSource<Int, DeckModel> {
     private let viewModel: DeckListViewModel
-    
+
     init(viewModel: DeckListViewModel, tableView: UITableView) {
         self.viewModel = viewModel
         super.init(tableView: tableView) { _, _, deckModel in
@@ -119,8 +119,8 @@ private class DeckListDiffableDataSource: UITableViewDiffableDataSource<Int, Dec
             return cell
         }
     }
-    
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        // TODO
+
+    override func tableView(_: UITableView, commit _: UITableViewCell.EditingStyle, forRowAt _: IndexPath) {
+        // TODO:
     }
 }

--- a/Spreppy/Deck List/DeckListViewController.swift
+++ b/Spreppy/Deck List/DeckListViewController.swift
@@ -69,8 +69,14 @@ class DeckListViewController: UIViewController,
     func update(state: DeckListState) {
         let oldState = self.state
         self.state = state
+        
+        if oldState.decks != state.decks {
+            var snapshot = NSDiffableDataSourceSnapshot<Int, DeckModel>()
+            snapshot.appendSections([0])
+            snapshot.appendItems(state.decks)
+            dataSource.apply(snapshot, animatingDifferences: true)
+        }
 
-        dataSource.apply(state.snapshot, animatingDifferences: true)
         if oldState.isEditing != state.isEditing {
             tableView.setEditing(state.isEditing, animated: true)
             navigationItem.setLeftBarButton(state.isEditing ? nil : addBarButton, animated: true)

--- a/Spreppy/Deck List/DeckListViewModel.swift
+++ b/Spreppy/Deck List/DeckListViewModel.swift
@@ -14,13 +14,13 @@ protocol DeckListViewModelDelegate: AnyObject {
 }
 
 struct DeckListState {
-    var snapshot: NSDiffableDataSourceSnapshot<Int, DeckModel>
+    var decks: [DeckModel]
     var isEditing: Bool
 
     init(
-        snapshot: NSDiffableDataSourceSnapshot<Int, DeckModel> = NSDiffableDataSourceSnapshot(),
+        decks: [DeckModel] = [],
         isEditing: Bool = false) {
-        self.snapshot = snapshot
+        self.decks = decks
         self.isEditing = isEditing
     }
 }
@@ -58,10 +58,7 @@ class DeckListViewModel {
         switch event {
         case .viewDidLoad:
             subscription = repository.fetchDeckList().sink { [weak self] deckList in
-                var snapshot = NSDiffableDataSourceSnapshot<Int, DeckModel>()
-                snapshot.appendSections([0])
-                snapshot.appendItems(deckList)
-                self?.state.snapshot = snapshot
+                self?.state.decks = deckList
             }
         case .addTapped:
             guard !state.isEditing else { assert(false); return }


### PR DESCRIPTION
Also refactors `DeckListState` to expose the decks directly instead of a snapshot.