### PR TITLE
Move Core Data calls to background and fix how they're subscribed to

### DIFF
--- a/Spreppy/Features/Deck Study/DeckStudyViewController.swift
+++ b/Spreppy/Features/Deck Study/DeckStudyViewController.swift
@@ -49,7 +49,7 @@ class DeckStudyViewController: UIViewController, DeckStudyViewModelDelegate {
     // MARK: DeckStudyViewModelDelegate
 
     func update(state: DeckStudyState) {
-        title = state.title
+        title = state.deck?.title
     }
 
     // MARK: Helpers

--- a/Spreppy/Features/Deck Study/DeckStudyViewModel.swift
+++ b/Spreppy/Features/Deck Study/DeckStudyViewModel.swift
@@ -37,7 +37,7 @@ class DeckStudyViewModel {
     private weak var delegate: DeckStudyViewModelDelegate?
 
     private var deckID: UUID
-    
+
     private var deckSubscription: AnyCancellable?
 
     init(

--- a/Spreppy/Features/Deck Study/DeckStudyViewModel.swift
+++ b/Spreppy/Features/Deck Study/DeckStudyViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by Russell Blickhan on 10/6/21.
 //
 
+import Combine
 import Foundation
 
 protocol DeckStudyViewModelDelegate: AnyObject {
@@ -12,10 +13,10 @@ protocol DeckStudyViewModelDelegate: AnyObject {
 }
 
 struct DeckStudyState {
-    var title: String
+    var deck: DeckModel?
 
-    init(title: String = "") {
-        self.title = title
+    init(deck: DeckModel? = nil) {
+        self.deck = deck
     }
 }
 
@@ -36,6 +37,8 @@ class DeckStudyViewModel {
     private weak var delegate: DeckStudyViewModelDelegate?
 
     private var deckID: UUID
+    
+    private var deckSubscription: AnyCancellable?
 
     init(
         deckID: UUID,
@@ -53,9 +56,11 @@ class DeckStudyViewModel {
     func handle(_ event: DeckStudyUIEvent) {
         switch event {
         case .viewDidLoad:
-            // TODO: https://github.com/rwblickhan/Spreppy/issues/17
-            // Update this to the name of the deck
-            state.title = deckID.uuidString
+            let (deck, deckUpdates) = repos.deckRepo.fetchDeck(deckID)
+            state.deck = deck
+            deckSubscription = deckUpdates.sink(receiveValue: { [weak self] deck in
+                self?.state.deck = deck
+            })
         case .addTapped:
             // TODO: https://github.com/rwblickhan/Spreppy/issues/18
             // Stub out a UI for this

--- a/Spreppy/Repositories/CardRepository.swift
+++ b/Spreppy/Repositories/CardRepository.swift
@@ -5,38 +5,117 @@
 //  Created by Russell Blickhan on 9/26/21.
 //
 
+import Combine
 import CoreData
 import Foundation
 
 protocol CardRepository {
+    func fetchCard(_ cardID: UUID) -> (CardModel?, AnyPublisher<CardModel, Never>)
     func createOrUpdate(_ cardModel: CardModel)
 }
 
 class CardCoreDataRepository: CardRepository {
-    private let persistentContainer: NSPersistentContainer
-
-    init(persistentContainer: NSPersistentContainer) {
-        self.persistentContainer = persistentContainer
+    private let viewContext: NSManagedObjectContext
+    private let backgroundContext: NSManagedObjectContext
+    
+    private typealias Update = (object: Card, type: UpdateType)
+    private enum UpdateType {
+        case insert, update, delete
     }
+    
+    private let state = CurrentValueSubject<[Update], Never>([])
 
+    init(viewContext: NSManagedObjectContext, backgroundContext: NSManagedObjectContext) {
+        self.viewContext = viewContext
+        self.backgroundContext = backgroundContext
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(viewContextDidSave),
+            name: .NSManagedObjectContextDidSave,
+            object: viewContext)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(backgroundContextDidSave),
+            name: .NSManagedObjectContextDidSave,
+            object: backgroundContext)
+    }
+    
+    func fetchCard(_ cardID: UUID) -> (CardModel?, AnyPublisher<CardModel, Never>) {
+        let fetchRequest = NSFetchRequest<Card>(entityName: CardModel.entityName)
+        fetchRequest.predicate = NSPredicate(format: "uuid == %@", cardID.uuidString)
+        fetchRequest.fetchLimit = 1
+        
+        let card = (try? viewContext.fetch(fetchRequest))?.first.flatMap { CardModel(managedObject: $0) }
+        let updatesPublisher: AnyPublisher<CardModel, Never> = state
+            .compactMap { updates -> Update? in
+                updates.first(where: { $0.object.uuid == cardID })
+            }
+            .compactMap { update -> Card? in
+                switch update.type {
+                case .insert, .update:
+                    return update.object
+                case .delete:
+                    return nil
+                }
+            }
+            .compactMap { CardModel(managedObject: $0) }
+            .eraseToAnyPublisher()
+        return (card, updatesPublisher)
+    }
+    
     func createOrUpdate(_ cardModel: CardModel) {
-        let managedObjectContext = persistentContainer.viewContext
         let fetchRequest = NSFetchRequest<Card>(entityName: CardModel.entityName)
         fetchRequest.predicate = NSPredicate(format: "uuid == %@", cardModel.uuid.uuidString)
         fetchRequest.fetchLimit = 1
-        // TODO: https://github.com/rwblickhan/Spreppy/issues/19
-        // This should really be done on a background queue
         let card: Card
-        if let fetchedCard = try? managedObjectContext.fetch(fetchRequest).first {
+        if let fetchedCard = try? backgroundContext.fetch(fetchRequest).first {
             card = fetchedCard
         } else {
             card = NSEntityDescription.insertNewObject(
                 forEntityName: CardModel.entityName,
-                into: persistentContainer.viewContext) as! Card
+                into: backgroundContext) as! Card
         }
-        card.configure(from: cardModel, managedObjectContext: managedObjectContext)
+        card.configure(from: cardModel, managedObjectContext: backgroundContext)
 
-        try! persistentContainer.viewContext.save()
+        try! backgroundContext.save()
+    }
+    
+    @objc private func viewContextDidSave(_ notification: Notification) {
+        guard
+            let context = notification.object as? NSManagedObjectContext,
+            context === viewContext
+        else { return }
+        
+        processUpdatesInViewContext(notification)
+        backgroundContext.perform {
+            self.backgroundContext.mergeChanges(fromContextDidSave: notification)
+        }
+    }
+    
+    @objc private func backgroundContextDidSave(_ notification: Notification) {
+        guard
+            let context = notification.object as? NSManagedObjectContext,
+            context === backgroundContext
+        else { return }
+        
+        viewContext.perform {
+            self.viewContext.mergeChanges(fromContextDidSave: notification)
+            self.processUpdatesInViewContext(notification)
+        }
+    }
+    
+    private func processUpdatesInViewContext(_ notification: Notification) {
+        let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject> ?? []
+        let updatedObjects = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> ?? []
+        let deletedObjects = notification.userInfo?[NSDeletedObjectsKey] as? Set<NSManagedObject> ?? []
+        
+        let updates: [(Card, UpdateType)] =
+            insertedObjects.compactMap { $0 as? Card }.map { ($0, .insert) } +
+            updatedObjects.compactMap { $0 as? Card }.map { ($0, .update) } +
+            deletedObjects.compactMap { $0 as? Card }.map { ($0, .delete) }
+        
+        state.send(updates)
     }
 }
 

--- a/Spreppy/Repositories/DeckRepository.swift
+++ b/Spreppy/Repositories/DeckRepository.swift
@@ -11,21 +11,33 @@ import Foundation
 
 protocol DeckRepository {
     func fetchDeckList() -> AnyPublisher<[DeckModel], Never>
+    func fetchDeck(_ deckID: UUID) -> (DeckModel?, AnyPublisher<DeckModel, Never>)
     func createOrUpdate(_ deckModel: DeckModel)
 }
 
 class DeckCoreDataRepository: NSObject, DeckRepository, NSFetchedResultsControllerDelegate {
-    private let persistentContainer: NSPersistentContainer
     private let deckListState = CurrentValueSubject<[DeckModel], Never>([])
     private let fetchedResultsController: NSFetchedResultsController<Deck>
+    
+    private let viewContext: NSManagedObjectContext
+    private let backgroundContext: NSManagedObjectContext
+    
+    private typealias Update = (object: Deck, type: UpdateType)
+    private enum UpdateType {
+        case insert, update, delete
+    }
+    
+    private let state = CurrentValueSubject<[Update], Never>([])
 
-    init(persistentContainer: NSPersistentContainer) {
-        self.persistentContainer = persistentContainer
+    init(viewContext: NSManagedObjectContext, backgroundContext: NSManagedObjectContext) {
+        self.viewContext = viewContext
+        self.backgroundContext = backgroundContext
+        
         let fetchRequest = Deck.fetchRequest()
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: "rank", ascending: true)]
         fetchedResultsController = NSFetchedResultsController(
             fetchRequest: fetchRequest,
-            managedObjectContext: persistentContainer.viewContext,
+            managedObjectContext: viewContext,
             sectionNameKeyPath: nil,
             cacheName: nil)
         super.init()
@@ -40,31 +52,99 @@ class DeckCoreDataRepository: NSObject, DeckRepository, NSFetchedResultsControll
         } catch {
             fatalError("###\(#function): Failed to performFetch: \(error)")
         }
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(viewContextDidSave),
+            name: .NSManagedObjectContextDidSave,
+            object: viewContext)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(backgroundContextDidSave),
+            name: .NSManagedObjectContextDidSave,
+            object: backgroundContext)
     }
 
     func fetchDeckList() -> AnyPublisher<[DeckModel], Never> {
         deckListState.eraseToAnyPublisher()
     }
+    
+    func fetchDeck(_ deckID: UUID) -> (DeckModel?, AnyPublisher<DeckModel, Never>) {
+        let fetchRequest = NSFetchRequest<Deck>(entityName: DeckModel.entityName)
+        fetchRequest.predicate = NSPredicate(format: "uuid == %@", deckID.uuidString)
+        fetchRequest.fetchLimit = 1
+        
+        let deck = (try? viewContext.fetch(fetchRequest))?.first.flatMap { DeckModel(managedObject: $0) }
+        let updatesPublisher: AnyPublisher<DeckModel, Never> = state
+            .compactMap { updates -> Update? in
+                updates.first(where: { $0.object.uuid == deckID })
+            }
+            .compactMap { update -> Deck? in
+                switch update.type {
+                case .insert, .update:
+                    return update.object
+                case .delete:
+                    return nil
+                }
+            }
+            .compactMap { DeckModel(managedObject: $0) }
+            .eraseToAnyPublisher()
+        return (deck, updatesPublisher)
+    }
 
     func createOrUpdate(_ deckModel: DeckModel) {
-        let managedObjectContext = persistentContainer.viewContext
         let fetchRequest = NSFetchRequest<Deck>(entityName: DeckModel.entityName)
         fetchRequest.predicate = NSPredicate(format: "uuid == %@", deckModel.uuid.uuidString)
         fetchRequest.fetchLimit = 1
-        // TODO: https://github.com/rwblickhan/Spreppy/issues/19
-        // This should really be done on a background queue
         let deck: Deck
-        if let fetchedDeck = try? managedObjectContext.fetch(fetchRequest).first {
+        if let fetchedDeck = try? backgroundContext.fetch(fetchRequest).first {
             deck = fetchedDeck
         } else {
             deck = NSEntityDescription.insertNewObject(
                 forEntityName: DeckModel.entityName,
-                into: persistentContainer.viewContext) as! Deck
+                into: backgroundContext) as! Deck
         }
 
-        deck.configure(from: deckModel, managedObjectContext: managedObjectContext)
+        deck.configure(from: deckModel, managedObjectContext: backgroundContext)
 
-        try! persistentContainer.viewContext.save()
+        try! backgroundContext.save()
+    }
+    
+    @objc private func viewContextDidSave(_ notification: Notification) {
+        guard
+            let context = notification.object as? NSManagedObjectContext,
+            context === viewContext
+        else { return }
+        
+        processUpdatesInViewContext(notification)
+        backgroundContext.perform {
+            self.backgroundContext.mergeChanges(fromContextDidSave: notification)
+        }
+    }
+    
+    @objc private func backgroundContextDidSave(_ notification: Notification) {
+        guard
+            let context = notification.object as? NSManagedObjectContext,
+            context === backgroundContext
+        else { return }
+        
+        viewContext.perform {
+            self.viewContext.mergeChanges(fromContextDidSave: notification)
+            self.processUpdatesInViewContext(notification)
+        }
+    }
+    
+    private func processUpdatesInViewContext(_ notification: Notification) {
+        let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject> ?? []
+        let updatedObjects = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> ?? []
+        let deletedObjects = notification.userInfo?[NSDeletedObjectsKey] as? Set<NSManagedObject> ?? []
+        
+        let updates: [(Deck, UpdateType)] =
+            insertedObjects.compactMap { $0 as? Deck }.map { ($0, .insert) } +
+            updatedObjects.compactMap { $0 as? Deck }.map { ($0, .update) } +
+            deletedObjects.compactMap { $0 as? Deck }.map { ($0, .delete) }
+        
+        state.send(updates)
     }
 
     // MARK: NSFetchedResultsControllerDelegate

--- a/Spreppy/Repositories/Repositories.swift
+++ b/Spreppy/Repositories/Repositories.swift
@@ -16,14 +16,14 @@ protocol Repositories {
 class CoreDataRepositories: Repositories {
     let cardRepo: CardRepository
     let deckRepo: DeckRepository
-    
+
     private let viewContext: NSManagedObjectContext
     private let backgroundContext: NSManagedObjectContext
 
     init(persistentContainer: NSPersistentContainer) {
-        self.viewContext = persistentContainer.viewContext
-        self.backgroundContext = persistentContainer.newBackgroundContext()
-        
+        viewContext = persistentContainer.viewContext
+        backgroundContext = persistentContainer.newBackgroundContext()
+
         cardRepo = CardCoreDataRepository(viewContext: viewContext, backgroundContext: backgroundContext)
         deckRepo = DeckCoreDataRepository(viewContext: viewContext, backgroundContext: backgroundContext)
     }

--- a/Spreppy/Repositories/Repositories.swift
+++ b/Spreppy/Repositories/Repositories.swift
@@ -16,9 +16,15 @@ protocol Repositories {
 class CoreDataRepositories: Repositories {
     let cardRepo: CardRepository
     let deckRepo: DeckRepository
+    
+    private let viewContext: NSManagedObjectContext
+    private let backgroundContext: NSManagedObjectContext
 
     init(persistentContainer: NSPersistentContainer) {
-        cardRepo = CardCoreDataRepository(persistentContainer: persistentContainer)
-        deckRepo = DeckCoreDataRepository(persistentContainer: persistentContainer)
+        self.viewContext = persistentContainer.viewContext
+        self.backgroundContext = persistentContainer.newBackgroundContext()
+        
+        cardRepo = CardCoreDataRepository(viewContext: viewContext, backgroundContext: backgroundContext)
+        deckRepo = DeckCoreDataRepository(viewContext: viewContext, backgroundContext: backgroundContext)
     }
 }

--- a/SpreppyTests/DeckStudyViewModelTests.swift
+++ b/SpreppyTests/DeckStudyViewModelTests.swift
@@ -40,9 +40,11 @@ class DeskStudyViewModelTests: XCTestCase {
     }
 
     func testHandleViewDidLoad() {
+        let deck = DeckModel(uuid: testUUID)
+        repos.deckRepoSpy.setDeckList([deck])
         subject = DeckStudyViewModel(deckID: testUUID, coordinator: coordinator, repos: repos, delegate: delegate)
         subject.handle(.viewDidLoad)
-        XCTAssertEqual(delegate.state.title, testUUID.uuidString)
+        XCTAssertEqual(delegate.state.deck, deck)
     }
 
     func testHandleAddTapped() {

--- a/SpreppyTests/RepositorySpies.swift
+++ b/SpreppyTests/RepositorySpies.swift
@@ -27,6 +27,12 @@ struct DeckRepositorySpy: DeckRepository {
     func fetchDeckList() -> AnyPublisher<[DeckModel], Never> {
         deckList.eraseToAnyPublisher()
     }
+    
+    func fetchDeck(_ deckID: UUID) -> (DeckModel?, AnyPublisher<DeckModel, Never>) {
+        let deck = deckList.value.first(where: { $0.uuid == deckID })
+        let publisher = deckList.compactMap { $0.first(where: { $0.uuid == deckID }) }.eraseToAnyPublisher()
+        return (deck, publisher)
+    }
 
     func createOrUpdate(_ deckModel: DeckModel) {
         var decks = deckList.value
@@ -45,6 +51,13 @@ struct DeckRepositorySpy: DeckRepository {
 
 struct CardRepositorySpy: CardRepository {
     let cardList = CurrentValueSubject<[CardModel], Never>([])
+    
+    func fetchCard(_ cardID: UUID) -> (CardModel?, AnyPublisher<CardModel, Never>) {
+        let card = cardList.value.first(where: { $0.uuid == cardID })
+        let publisher = cardList.compactMap { $0.first(where: { $0.uuid == cardID }) }.eraseToAnyPublisher()
+        return (card, publisher)
+    }
+    
     func createOrUpdate(_ cardModel: CardModel) {
         var cards = cardList.value
         if let (i, _) = cardList.value.enumerated().first(where: { $0.element.uuid == cardModel.uuid }) {

--- a/SpreppyTests/RepositorySpies.swift
+++ b/SpreppyTests/RepositorySpies.swift
@@ -27,7 +27,7 @@ struct DeckRepositorySpy: DeckRepository {
     func fetchDeckList() -> AnyPublisher<[DeckModel], Never> {
         deckList.eraseToAnyPublisher()
     }
-    
+
     func fetchDeck(_ deckID: UUID) -> (DeckModel?, AnyPublisher<DeckModel, Never>) {
         let deck = deckList.value.first(where: { $0.uuid == deckID })
         let publisher = deckList.compactMap { $0.first(where: { $0.uuid == deckID }) }.eraseToAnyPublisher()
@@ -51,13 +51,13 @@ struct DeckRepositorySpy: DeckRepository {
 
 struct CardRepositorySpy: CardRepository {
     let cardList = CurrentValueSubject<[CardModel], Never>([])
-    
+
     func fetchCard(_ cardID: UUID) -> (CardModel?, AnyPublisher<CardModel, Never>) {
         let card = cardList.value.first(where: { $0.uuid == cardID })
         let publisher = cardList.compactMap { $0.first(where: { $0.uuid == cardID }) }.eraseToAnyPublisher()
         return (card, publisher)
     }
-    
+
     func createOrUpdate(_ cardModel: CardModel) {
         var cards = cardList.value
         if let (i, _) = cardList.value.enumerated().first(where: { $0.element.uuid == cardModel.uuid }) {


### PR DESCRIPTION
Closes #17; closes #19.

This moves Core Data mutation calls to a background context and also introduces subscribing to individual objects. Incidentally, this allows us to implement showing the title of the deck in the deck study view.